### PR TITLE
Increment version to 0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ersatz-jjy VERSION 0.3)
+project(ersatz-jjy VERSION 0.4)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 configure_file(ersatz-jjy-config.h.in ersatz-jjy-config.h)


### PR DESCRIPTION
Creating a new release of ersatz-jjy to capture the interrupt handling that has been added