### PR TITLE
Improve performance on SBCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ersatz-jjy VERSION 0.5)
+project(ersatz-jjy VERSION 0.6)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 configure_file(ersatz-jjy-config.h.in ersatz-jjy-config.h)


### PR DESCRIPTION
Testing on a Raspberry Pi CM4 revealed poor audio buffering with ersatz-jjy. Increasing the sample buffer size to 512 and using signed 16-bit integer samples instead of PortAudio's 32-bit floating point sample format that ranges from -1.0 to 1.0 seems to help. Additionally, this commit lowers the audio output sample rate from 48kHz to the ubiquitous rate of 44.1kHz, though this requires larger wavetables for sine wave output. For ersatz-wwvb this commit maintains a 48kHz sample rate to allow for accurate 180-degree phase-shifting using only the wavetable index.